### PR TITLE
JSON editing includes wrong double quotes

### DIFF
--- a/resources/index.html
+++ b/resources/index.html
@@ -30,7 +30,7 @@
 
       <section class="json input">
         <label for="notificationPayload">Notification payload</label>
-        <textarea id="notificationPayload" oninput="setPayload(event)"></textarea>
+        <textarea id="notificationPayload" style="min-height: 160px"></textarea>
       </section>
 
       <section class="devices" aria-label="available devices">

--- a/resources/js/main.js
+++ b/resources/js/main.js
@@ -5,6 +5,7 @@ const DEFAULT_PAYLOAD = {
         sound: 'default',
         badge: 1,
     },
+    message_id: '00000000000000000000000000'
 };
 
 class PNTarget {
@@ -87,17 +88,21 @@ function setBundleId(event) {
     target.bundleId = event.target.value || null;
 }
 
-function setPayload(event) {
+
+function setPayload(value) {
     try {
-        const nextPayload = JSON.parse(event.target.value);
-        target.payload = nextPayload ? nextPayload : null;
+        // replace back double quotes into quotes ” -> "
+        // it seems to be auto-replaced while writing in the text area in window mode
+        const replaced = value.replaceAll(String.fromCharCode(8220),'"').replaceAll(String.fromCharCode(8221),'"');
+        const nextPayload = JSON.parse(replaced);
+        target.payload = nextPayload ?? null;
     } catch (e) {
-        console.log(e);
         target.payload = null;
     }
 }
 
 function sendNotification() {
+    setPayload(document.getElementById('notificationPayload').value);
     const command = target.getCommand();
     if (command) {
         Neutralino.os
@@ -125,13 +130,13 @@ function sendNotification() {
         if (target.uuid === null) {
             errors.push('must select a device');
         }
-        document.getElementById('statusBar').innerHTML = `Error: ${errors.join(', ')}`;
+        document.getElementById('statusBar').innerHTML = `Errors ${errors.map(e => `<br/>- ${e}`).join("")}`;
         document.getElementById('statusBar').classList = ['error'];
     }
 }
 
 function setTray() {
-    if (NL_MODE != 'window') {
+    if (NL_MODE !== 'window') {
         console.log('INFO: Tray menu is only available in the window mode.');
         return;
     }
@@ -172,7 +177,7 @@ Neutralino.window.setSize({
 Neutralino.events.on('trayMenuItemClicked', onTrayMenuItemClicked);
 Neutralino.events.on('windowClose', onWindowClose);
 
-if (NL_OS != 'Darwin') {
+if (NL_OS !== 'Darwin') {
     // TODO: Fix https://github.com/neutralinojs/neutralinojs/issues/615
     setTray();
 }

--- a/resources/js/main.js
+++ b/resources/js/main.js
@@ -91,8 +91,8 @@ function setBundleId(event) {
 
 function setPayload(value) {
     try {
-        // replace back double quotes into quotes ” -> "
-        // it seems to be auto-replaced while writing in the text area in window mode
+        // force the replacement of back double quotes into quotes ” -> "
+        // it seems to be auto-replaced while writing in the text area (only in window mode)
         const replaced = value.replaceAll(String.fromCharCode(8220),'"').replaceAll(String.fromCharCode(8221),'"');
         const nextPayload = JSON.parse(replaced);
         target.payload = nextPayload ?? null;


### PR DESCRIPTION
This PR aims to fix a bad experience while editing the JSON payload.
Due to unknown bug (I didn't found any reference of it, but it seems to appear only in `window` mode, not in `browser` mode) the textarea converts the double quotes in left/right quotation mark. This auto-replacement results in an invalid JSON payload

- double quotes -> ascii code 34 `"` 
- left double quotation mark -> ascii code 8220 `“`
- right double quotation mark -> ascii code 8221 `”`

### before
https://user-images.githubusercontent.com/822471/162400113-fee97134-5c0e-4d2b-b32f-42d2cd95ce22.mov

### now
https://user-images.githubusercontent.com/822471/162400140-26f50326-4e11-4c15-8c5d-ccacb2e19f83.mov

It also includes an improvement of the error displaying
| before  | now |
| ------------- | ------------- |
![Preferences](https://user-images.githubusercontent.com/822471/162401030-4a9546b4-52df-4457-973a-13ec01e3de2a.png) | ![Privacy](https://user-images.githubusercontent.com/822471/162401032-55612857-7a1b-4fb6-93c7-5a9e2284bb4c.png)

